### PR TITLE
Add doctor-patient request system

### DIFF
--- a/app/Enums/FollowingStatus.php
+++ b/app/Enums/FollowingStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum FollowingStatus: string
+{
+    case PENDING = 'pending';
+    case ACCEPTED = 'accepted';
+    case REJECTED = 'rejected';
+}

--- a/app/Filament/Medecin/Resources/PatientResource.php
+++ b/app/Filament/Medecin/Resources/PatientResource.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Filament\Medecin\Resources;
+
+use App\Enums\FollowingStatus;
+use App\Filament\Medecin\Resources\PatientResource\Pages;
+use App\Models\Following;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class PatientResource extends Resource
+{
+    protected static ?string $model = Following::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+    protected static ?string $navigationLabel = 'Mes patients';
+
+    public static function form(Form $form): Form
+    {
+        return $form;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('patient.name')->label('Patient')->searchable(),
+                TextColumn::make('status')->label('Statut')->badge(),
+            ])
+            ->actions([
+                Action::make('accept')
+                    ->label('Accepter')
+                    ->visible(fn (Following $record) => $record->status === FollowingStatus::PENDING)
+                    ->action(fn (Following $record) => $record->update(['status' => FollowingStatus::ACCEPTED])),
+                Action::make('reject')
+                    ->label('Rejeter')
+                    ->color('danger')
+                    ->visible(fn (Following $record) => $record->status === FollowingStatus::PENDING)
+                    ->action(fn (Following $record) => $record->update(['status' => FollowingStatus::REJECTED])),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return Following::query()->where('doctor_id', Auth::id())->with('patient');
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPatients::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Medecin/Resources/PatientResource/Pages/ListPatients.php
+++ b/app/Filament/Medecin/Resources/PatientResource/Pages/ListPatients.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Medecin\Resources\PatientResource\Pages;
+
+use App\Filament\Medecin\Resources\PatientResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPatients extends ListRecords
+{
+    protected static string $resource = PatientResource::class;
+}

--- a/app/Filament/Patient/Pages/DoctorSearch.php
+++ b/app/Filament/Patient/Pages/DoctorSearch.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Patient\Pages;
+
+use App\Enums\FollowingStatus;
+use App\Models\Following;
+use App\Models\User;
+use App\Enums\UserRoles;
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\Auth;
+use Livewire\WithPagination;
+
+class DoctorSearch extends Page
+{
+    use WithPagination;
+
+    protected static ?string $navigationLabel = 'Trouver un médecin';
+    protected static ?string $title = 'Recherche de médecins';
+    protected static ?string $slug = 'doctor-search';
+    protected static string $view = 'filament.patient.pages.doctor-search';
+
+    public string $search = '';
+
+    public function getDoctorsProperty()
+    {
+        return User::where('role', UserRoles::DOCTOR)
+            ->when($this->search, function ($query) {
+                $query->where('name', 'like', "%{$this->search}%")
+                    ->orWhere('email', 'like', "%{$this->search}%");
+            })->paginate(8);
+    }
+
+    public function requestFollow(int $doctorId): void
+    {
+        if (Following::where('patient_id', Auth::id())->exists()) {
+            $this->notify('danger', 'Vous avez déjà une demande en cours ou un médecin.');
+            return;
+        }
+
+        Following::create([
+            'patient_id' => Auth::id(),
+            'doctor_id' => $doctorId,
+            'status' => FollowingStatus::PENDING,
+        ]);
+
+        $this->notify('success', 'Demande envoyée.');
+    }
+}

--- a/app/Models/Following.php
+++ b/app/Models/Following.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\FollowingStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Following extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'patient_id',
+        'doctor_id',
+        'status',
+    ];
+
+    protected $casts = [
+        'status' => FollowingStatus::class,
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'patient_id');
+    }
+
+    public function doctor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'doctor_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -100,6 +100,16 @@ class User extends Authenticatable implements FilamentUser
         return $this->belongsToMany(User::class, 'followings', 'doctor_id');
     }
 
+    public function followingRequest()
+    {
+        return $this->hasOne(Following::class, 'patient_id');
+    }
+
+    public function receivedRequests()
+    {
+        return $this->hasMany(Following::class, 'doctor_id');
+    }
+
 
     /**
      * @throws \Exception

--- a/database/migrations/2025_06_08_193607_update_followings_table.php
+++ b/database/migrations/2025_06_08_193607_update_followings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('followings', function (Blueprint $table) {
+            $table->string('status')->default('pending');
+            $table->unique('patient_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('followings', function (Blueprint $table) {
+            $table->dropUnique(['patient_id']);
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/resources/views/filament/patient/pages/doctor-search.blade.php
+++ b/resources/views/filament/patient/pages/doctor-search.blade.php
@@ -1,0 +1,25 @@
+<x-filament-panels::page>
+    <div class="space-y-4">
+        <input
+            wire:model.debounce.500ms="search"
+            type="text"
+            placeholder="Rechercher un médecin..."
+            class="filament-input w-full max-w-md"
+        />
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            @foreach($this->doctors as $doctor)
+                <div class="bg-white p-4 rounded shadow text-center">
+                    <img src="{{ asset('doctor.jpeg') }}" class="w-24 h-24 mx-auto rounded-full object-cover" alt="">
+                    <div class="mt-2 font-medium">{{ $doctor->name }}</div>
+                    <div class="text-sm text-gray-500">{{ $doctor->email }}</div>
+                    <button wire:click="requestFollow({{ $doctor->id }})" class="mt-3 filament-button">
+                        Demander
+                    </button>
+                </div>
+            @endforeach
+        </div>
+
+        {{ $this->doctors->links() }}
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- allow only one doctor per patient
- support request status via enum and model
- add doctor search page with realtime Livewire search for patients
- add doctor-side resource to accept or reject patient requests
- migration for followings table

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5741094832da25b49ec9cdc9c5c