### PR TITLE
Add doctor patient analytics view

### DIFF
--- a/app/Filament/Medecin/Pages/PatientAnalytics.php
+++ b/app/Filament/Medecin/Pages/PatientAnalytics.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Filament\Medecin\Pages;
+
+use App\Models\User;
+use App\Models\Glycemie;
+use Filament\Pages\Page;
+
+class PatientAnalytics extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
+
+    protected static string $view = 'filament.medecin.pages.patient-analytics';
+
+    protected static ?string $title = 'Analyse patient';
+
+    protected static ?string $slug = 'patient-analytics';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public User $patient;
+
+    public function mount(int $record): void
+    {
+        $this->patient = User::with('patientProfile')->findOrFail($record);
+    }
+
+    public function getGlycemiesProperty()
+    {
+        return Glycemie::where('patient_id', $this->patient->id)
+            ->orderByDesc('date_mesure')
+            ->orderByDesc('heure_mesure')
+            ->take(10)
+            ->get();
+    }
+}

--- a/app/Filament/Medecin/Resources/PatientResource.php
+++ b/app/Filament/Medecin/Resources/PatientResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Medecin\Resources;
 
 use App\Enums\FollowingStatus;
 use App\Filament\Medecin\Resources\PatientResource\Pages;
+use App\Filament\Medecin\Pages\PatientAnalytics;
 use App\Models\Following;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -43,6 +44,11 @@ class PatientResource extends Resource
                     ->color('danger')
                     ->visible(fn (Following $record) => $record->status === FollowingStatus::PENDING)
                     ->action(fn (Following $record) => $record->update(['status' => FollowingStatus::REJECTED])),
+                Action::make('analytics')
+                    ->label('Voir analyse')
+                    ->icon('heroicon-o-chart-bar')
+                    ->visible(fn (Following $record) => $record->status === FollowingStatus::ACCEPTED)
+                    ->url(fn (Following $record) => PatientAnalytics::getUrl(['record' => $record->patient_id])),
             ])
             ->bulkActions([]);
     }

--- a/app/Providers/Filament/MedecinPanelProvider.php
+++ b/app/Providers/Filament/MedecinPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Medecin\Pages\DoctorRegister;
+use App\Filament\Medecin\Pages\PatientAnalytics;
 use App\Filament\Shared\Pages\Chat;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -40,7 +41,7 @@ class MedecinPanelProvider extends PanelProvider
                 Pages\Dashboard::class,
                 Chat::class,
                 PatientGlycemieHistory::class,
-
+                PatientAnalytics::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Medecin/Widgets'), for: 'App\\Filament\\Medecin\\Widgets')
             ->widgets([

--- a/resources/views/filament/medecin/pages/patient-analytics.blade.php
+++ b/resources/views/filament/medecin/pages/patient-analytics.blade.php
@@ -1,0 +1,48 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow p-6">
+            <h2 class="text-xl font-semibold">{{ $this->patient->name }}</h2>
+            @php($profile = $this->patient->patientProfile)
+            @if($profile)
+                <p>Date de naissance : {{ \Carbon\Carbon::parse($profile->date_of_birth)->format('d/m/Y') }}</p>
+                <p>Genre : {{ $profile->gender }}</p>
+                <p>Taille : {{ $profile->height }} cm</p>
+                <p>Poids : {{ $profile->weight }} kg</p>
+                <p>Antécédents médicaux : {{ $profile->medical_history }}</p>
+                <p>Allergies : {{ $profile->allergies }}</p>
+            @endif
+        </div>
+
+        <div class="bg-white rounded-lg shadow overflow-hidden">
+            <div class="p-6">
+                <h3 class="text-lg font-medium text-gray-900">Dernières mesures de glycémie</h3>
+            </div>
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Heure</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Valeur</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Moment</th>
+                </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                @foreach($this->glycemies as $g)
+                    <tr>
+                        <td class="px-4 py-2">{{ $g->date_mesure->format('d/m/Y') }}</td>
+                        <td class="px-4 py-2">{{ $g->heure_mesure }}</td>
+                        <td class="px-4 py-2">{{ $g->valeur }} mmol/L</td>
+                        <td class="px-4 py-2">{{ ucfirst($g->moment) }}</td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div class="flex justify-end">
+            <x-filament::button tag="a" href="{{ route('filament.medecin.pages.chat') }}">
+                Contacter le patient
+            </x-filament::button>
+        </div>
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- create `PatientAnalytics` doctor page to show patient profile and recent measures
- register the analytics page in the Medecin panel provider
- expose an `analytics` action in `PatientResource`

## Testing
- `composer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e98055ac832d981ca8553ea97303